### PR TITLE
build_pfs: fix GitHub API media type

### DIFF
--- a/bin/build_pfs.sh
+++ b/bin/build_pfs.sh
@@ -35,7 +35,7 @@ build_package () {
 
     setup -k -r .
     scons
-    version=$(curl --fail --location --insecure --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/${repo}/commits/${commit} || curl --fail --location --insecure --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/${repo}/commits/master)
+    version=$(curl --fail --location --insecure --header "Accept: application/vnd.github.sha" https://api.github.com/repos/${repo}/commits/${commit} || curl --fail --location --insecure --header "Accept: application/vnd.github.sha" https://api.github.com/repos/${repo}/commits/master)
     scons_args=" version=${version}"
     [ -n "$tag" ] && scons_args+=" --tag=$tag"
     scons install declare ${scons_args}


### PR DESCRIPTION
The ".VERSION" should have been ".v3"; but it's optional
so leave it out completely.

Thanks to Atsushi Shimono for identifying this.