### PR TITLE
PIPE2D-295: Fix use of GitHub API

### DIFF
--- a/bin/build_pfs.sh
+++ b/bin/build_pfs.sh
@@ -35,8 +35,7 @@ build_package () {
 
     setup -k -r .
     scons
-    version=$(curl --fail --location --insecure --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/${repo}/commits/${commit} || curl --fail --location --insecure --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/${repo}/commits/master)
-    scons_args=" version=${version}"
+    scons_args=" version=$commit"
     [ -n "$tag" ] && scons_args+=" --tag=$tag"
     scons install declare ${scons_args}
 


### PR DESCRIPTION
This saves us using the GitHub API, which is subject to rate limits.
This may make the system more robust under Travis, where we seem to
frequently hit the rate limit.