### PR TITLE
generateCommands.py: run each calibBlock in a separate rerun-dir

### DIFF
--- a/python/pfs/pipe2d/generateCommands.py
+++ b/python/pfs/pipe2d/generateCommands.py
@@ -959,11 +959,12 @@ class CalibBlock:
         for typeName in calibTypes:
             if typeName in self.sources:
                 self.sources[typeName].execute(
-                    fout, dataDir, calib, f"{rerun}/{typeName}", processes=processes, devel=devel)
+                    fout, dataDir, calib, f"{rerun}/{self.name}/{typeName}",
+                    processes=processes, devel=devel)
                 self.sources[typeName].ingest(
-                    fout, dataDir, calib, f"{rerun}/{typeName}", copyMode, overwrite=overwrite)
+                    fout, dataDir, calib, f"{rerun}/{self.name}/{typeName}", copyMode, overwrite=overwrite)
                 if clean:
-                    self.sources[typeName].clean(fout, dataDir, f"{rerun}/{typeName}")
+                    self.sources[typeName].clean(fout, dataDir, f"{rerun}/{self.name}/{typeName}")
 
 
 @export

--- a/python/pfs/pipe2d/weekly/test_weekly.py
+++ b/python/pfs/pipe2d/weekly/test_weekly.py
@@ -81,7 +81,8 @@ class ProductionTestCase(lsst.utils.tests.TestCase):
 )
 class ArcTestCase(lsst.utils.tests.TestCase):
     def setUp(self):
-        self.butler = Butler(os.path.join(weeklyRerun, "calib", self.arms, "detectorMap"))
+        self.butler = Butler(os.path.join(weeklyRerun, "calib", self.arms,
+                                          f"arc_{self.arms}", "detectorMap"))
 
     def tearDown(self):
         del self.butler


### PR DESCRIPTION
Previously, a calibType of one calibBlock were constructed
in the same rerun-directory as the calibType of another calibBlock.
Without --clean option, the products of the two calibTypes were
intermingled with each other, and the latter product could not be
ingested properly. Now, the two calibTypes are constructed in separate
directories.