### PR TITLE
PIPE2D-1087: Add support for intermediate weeklies.

### DIFF
--- a/python/pfs/pipe2d/gitChangelog.py
+++ b/python/pfs/pipe2d/gitChangelog.py
@@ -313,6 +313,14 @@ def writeHtml(
         writer.write("<body>\n")
         writer.write("<h1>PFS 2D DRP Changelog</h1>\n")
 
+        gen_date = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M +00:00")
+        repos = ", ".join(os.path.basename(r) for r in sorted(repositories))
+        writer.write(
+            f"<p>Generated at {hescape(gen_date)} "
+            "based on the following"
+            f" repositories: {hescape(repos)}.</p>\n"
+        )
+
         # Always do the not-in-tag tickets first if they exist.
         if NOT_TAGGED in changelog:
             writeTagSummary(writer, NOT_TAGGED, changelog.pop(NOT_TAGGED))
@@ -321,13 +329,6 @@ def writeHtml(
         for tag in sorted(changelog, reverse=True, key=tagKey):
             writeTagSummary(writer, tag, changelog[tag])
 
-        gen_date = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M +00:00")
-        repos = ", ".join(os.path.basename(r) for r in sorted(repositories))
-        writer.write(
-            f"<p>Generated at {hescape(gen_date)} "
-            "based on the following"
-            f" repositories: {hescape(repos)}.</p>\n"
-        )
         writer.write("</body>\n")
         writer.write("</html>\n")
 

--- a/python/pfs/pipe2d/gitChangelog.py
+++ b/python/pfs/pipe2d/gitChangelog.py
@@ -40,9 +40,9 @@ The regular expression of the standard message generated when a ticket branch
 is merged to master.
 """
 
-TAG_REGEX = re.compile(r"^w\.(\d{4})\.(\d{2})$")
+TAG_REGEX = re.compile(r"^w\.(\d{4})\.(\d{2}[a-zA-Z]*)$")
 """Git tag regular expression (`re.Pattern`).
-The format of a tag. In the above case, for weeklies eg w.2022.17 .
+The format of a tag. In the above case, for weeklies eg 'w.2022.17', 'w.2022.40a' .
 """
 
 NOT_TAGGED = "NOT-TAGGED"
@@ -277,7 +277,7 @@ def writeTagSummary(
 
 
 def tagKey(tagname: str) -> Tuple[int, ...]:
-    """Converts a tagname ("w.YYYY.WW") into a key for sorting.
+    """Converts a tagname ("w.YYYY.WWx") into a key for sorting.
 
     Parameters
     ----------
@@ -286,10 +286,10 @@ def tagKey(tagname: str) -> Tuple[int, ...]:
 
     Returns
     -------
-    sortKey : tuple[`int`, ...]
+    sortKey : tuple[`str`, ...]
         numerical key for sorting.
     """
-    return tuple(int(i) for i in tagname[2:].split("."))
+    return tuple(tagname[2:].split("."))
 
 
 def writeHtml(


### PR DESCRIPTION
So support weekly tags such as 'w.2022.40a' in addition to 'w.2022.40'.