### PR TITLE
PIPE2D-1095: process_science.sh: ignore n-band data temporarily.

### DIFF
--- a/examples/science.yaml
+++ b/examples/science.yaml
@@ -4,7 +4,7 @@
 scienceBlock:
   -
     name: brn
-    id: "visit=1000^1001^1004^1005"
+    id: ["visit=1000^1001^1004^1005", "arm=b^r"]
   -
     name: bmn
-    id: "visit=1002^1003^1006^1007"
+    id: ["visit=1002^1003^1006^1007", "arm=b^m"]


### PR DESCRIPTION
This will be reverted as part of PIPE2D-1088.