### PR TITLE
PIPE2D-1107: Replace ingestCuratedCalibs calls with ingestPfsDefects

### DIFF
--- a/bin/pfs_integration_test.sh
+++ b/bin/pfs_integration_test.sh
@@ -146,8 +146,8 @@ if $RUN_GEN2; then
             $drp_stella_data/raw/PFFA*.fits \
             -c clobber=True register.ignore=True
 
-        mkdir $TARGET/stagingArea
-        ingestPfsDefects --lam $TARGET/stagingArea $TARGET --calib $TARGET/CALIB --config clobber=True
+        makePfsDefects --lam
+        ingestCuratedCalibs.py "$TARGET" --calib "$TARGET"/CALIB "$DRP_PFS_DATA_DIR"/curated/pfs/defects
 
         # Build calibs
         generateCommands.py "$TARGET" \
@@ -202,6 +202,7 @@ if $RUN_GEN3; then
     butler ingest-raws $DATASTORE $drp_stella_data/raw/PFFA*.fits --ingest-task lsst.obs.pfs.gen3.PfsRawIngestTask --transfer link --fail-fast
     ingestPfsConfig.py $DATASTORE lsst.obs.pfs.PfsSimulator PFS-F/raw/pfsConfig simulator $drp_stella_data/raw/pfsConfig*.fits --transfer link
     butler ingest-files $DATASTORE detectorMap_bootstrap PFS-F/detectorMap/bootstrap --prefix $DRP_PFS_DATA_DIR/detectorMap $DRP_PFS_DATA_DIR/detectorMap/detectorMap-sim.ecsv --transfer copy
+    makePfsDefects --lam
     butler write-curated-calibrations $DATASTORE lsst.obs.pfs.PfsSimulator
 
     # Calibs

--- a/bin/pfs_integration_test.sh
+++ b/bin/pfs_integration_test.sh
@@ -146,7 +146,8 @@ if $RUN_GEN2; then
             $drp_stella_data/raw/PFFA*.fits \
             -c clobber=True register.ignore=True
 
-        ingestCuratedCalibs.py "$TARGET" --calib "$TARGET"/CALIB "$DRP_PFS_DATA_DIR"/curated/pfs/defects
+        mkdir $TARGET/stagingArea
+        ingestPfsDefects --lam $TARGET/stagingArea $TARGET --calib $TARGET/CALIB --config clobber=True
 
         # Build calibs
         generateCommands.py "$TARGET" \

--- a/weekly/process_weekly.sh
+++ b/weekly/process_weekly.sh
@@ -62,8 +62,8 @@ echo "lsst.obs.pfs.PfsMapper" > $WORKDIR/_mapper
 ingestPfsImages.py $WORKDIR $DATADIR/PFFA*.fits
 
 # Ingest defects
-mkdir $WORKDIR/stagingArea
-ingestPfsDefects --lam $WORKDIR/stagingArea $WORKDIR --calib $WORKDIR/CALIB --config clobber=True
+makePfsDefects --lam
+ingestCuratedCalibs.py $WORKDIR --calib $WORKDIR/CALIB $DRP_PFS_DATA_DIR/curated/pfs/defects
 
 # Build calibs
 develFlag=""

--- a/weekly/process_weekly.sh
+++ b/weekly/process_weekly.sh
@@ -62,7 +62,8 @@ echo "lsst.obs.pfs.PfsMapper" > $WORKDIR/_mapper
 ingestPfsImages.py $WORKDIR $DATADIR/PFFA*.fits
 
 # Ingest defects
-ingestCuratedCalibs.py $WORKDIR --calib $WORKDIR/CALIB $DRP_PFS_DATA_DIR/curated/pfs/defects
+mkdir $WORKDIR/stagingArea
+ingestPfsDefects --lam $WORKDIR/stagingArea $WORKDIR --calib $WORKDIR/CALIB --config clobber=True
 
 # Build calibs
 develFlag=""


### PR DESCRIPTION
Following PIPE2D-1094, calls to ingestCuratedCalibs.py should be changed to ingestPfsDefects to support the new organization of H4RG defects.