### PR TITLE
PIPE2D-1301: generateCommands: Use reduceProfiles instead of constructFiberProfiles

### DIFF
--- a/examples/integration_test.yaml
+++ b/examples/integration_test.yaml
@@ -28,15 +28,8 @@ calibBlock:
       config:
         - "isr.doCrosstalk=False"  # No crosstalk in simulated data
     fiberProfiles:
-      group:
-        -
-          id: "field=FLAT_ODD"
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
-        -
-          id: "field=FLAT_EVEN"
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
+      id: "field=FLAT_ODD^FLAT_EVEN"
+      normId: ["field=FLAT", "dither=0"]
     detectorMap:
       id: "field=ARC"
       config:

--- a/examples/integration_test.yaml
+++ b/examples/integration_test.yaml
@@ -30,6 +30,8 @@ calibBlock:
     fiberProfiles:
       id: "field=FLAT_ODD^FLAT_EVEN"
       normId: ["field=FLAT", "dither=0"]
+      config:
+        - "reduceExposure.isr.doCrosstalk=False"  # No crosstalk in simulated data
     detectorMap:
       id: "field=ARC"
       config:

--- a/examples/weekly.yaml
+++ b/examples/weekly.yaml
@@ -38,11 +38,19 @@ calibBlock:
     fiberProfiles:
       id: ["visit=35^37", "arm=b^r^n"]
       normId: ["field=FLAT", "arm=b^r^n", "dither=0"]
+      config:
+        - "reduceExposure.isr.doCrosstalk=False"  # No crosstalk in simulated data
+        - "reduceExposure.isr.doIPC=False"  # No IPC in simulated data
+        - "profiles.profileSwath=2000"  # Not much variation
   -
     name: calibs_for_m
     fiberProfiles:
       id: ["visit=36^38", "arm=m"]
       normId: ["field=FLAT", "arm=m", "dither=0"]
+      config:
+        - "reduceExposure.isr.doCrosstalk=False"  # No crosstalk in simulated data
+        - "reduceExposure.isr.doIPC=False"  # No IPC in simulated data
+        - "profiles.profileSwath=2000"  # Not much variation
   -
     name: arc_brn
     detectorMap:

--- a/examples/weekly.yaml
+++ b/examples/weekly.yaml
@@ -31,13 +31,13 @@ calibBlock:
         - "isr.doCrosstalk=False"  # No crosstalk in simulated data
         - "isr.doIPC=False"  # No IPC in simulated data
     flat:
-      id: ["field=FLAT", "arm=b^r^n"]
+      id: ["visit=20..22^26..37", "arm=b^r^n"]
       config:
         - "isr.doCrosstalk=False"  # No crosstalk in simulated data
         - "isr.doIPC=False"  # No IPC in simulated data
     fiberProfiles:
-      id: ["visit=35^37", "arm=b^r^n"]
-      normId: ["field=FLAT", "arm=b^r^n", "dither=0"]
+      id: ["visit=38^40", "arm=b^r^n"]
+      normId: ["visit=20..22", "arm=b^r^n", "dither=0"]
       config:
         - "reduceExposure.isr.doCrosstalk=False"  # No crosstalk in simulated data
         - "reduceExposure.isr.doIPC=False"  # No IPC in simulated data
@@ -45,7 +45,7 @@ calibBlock:
   -
     name: calibs_for_m
     fiberProfiles:
-      id: ["visit=36^38", "arm=m"]
+      id: ["field=FLAT_ODD^FLAT_EVEN", "arm=m"]
       normId: ["field=FLAT", "arm=m", "dither=0"]
       config:
         - "reduceExposure.isr.doCrosstalk=False"  # No crosstalk in simulated data
@@ -54,7 +54,7 @@ calibBlock:
   -
     name: arc_brn
     detectorMap:
-      id: ["visit=39..45:2", "arm=b^r^n"]
+      id: ["visit=42..48:2", "arm=b^r^n"]
       config:
         - "fitDetectorMap.doSlitOffsets=True"
         - "fitDetectorMap.minSignalToNoise=20"
@@ -63,7 +63,7 @@ calibBlock:
   -
     name: arc_m
     detectorMap:
-      id: ["visit=40..46:2", "arm=m"]
+      id: ["visit=43..49:2", "arm=m"]
       config:
         - "fitDetectorMap.doSlitOffsets=True"
         - "fitDetectorMap.minSignalToNoise=20"
@@ -76,7 +76,7 @@ calibBlock:
 scienceBlock:
   -
     name: pipeline_on_brn
-    id: ["visit=47^48^49^53^54^57"]
+    id: ["visit=50..52^56^57^60"]
     policy:
       reduceExposure:
         config:
@@ -86,7 +86,7 @@ scienceBlock:
           - "repair.cosmicray.cond3_fac=10"
   -
     name: pipeline_on_bmn
-    id: ["visit=50^51^52^55^56^58"]
+    id: ["visit=53..55^58^59^61"]
     policy:
       reduceExposure:
         config:

--- a/examples/weekly.yaml
+++ b/examples/weekly.yaml
@@ -36,32 +36,13 @@ calibBlock:
         - "isr.doCrosstalk=False"  # No crosstalk in simulated data
         - "isr.doIPC=False"  # No IPC in simulated data
     fiberProfiles:
-      group:
-        -
-          id: ["visit=35", "arm=b^r^n"]
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
-            - "isr.doIPC=False"  # No IPC in simulated data
-        -
-          id: ["visit=37", "arm=b^r^n"]
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
-            - "isr.doIPC=False"  # No IPC in simulated data
+      id: ["visit=35^37", "arm=b^r^n"]
+      normId: ["field=FLAT", "arm=b^r^n", "dither=0"]
   -
     name: calibs_for_m
     fiberProfiles:
-      group:
-        -
-          id: ["visit=36", "arm=m"]
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
-            - "isr.doIPC=False"  # No IPC in simulated data
-        -
-          id: ["visit=38", "arm=m"]
-          config:
-            - "isr.doCrosstalk=False"  # No crosstalk in simulated data
-            - "isr.doIPC=False"  # No IPC in simulated data
-
+      id: ["visit=36^38", "arm=m"]
+      normId: ["field=FLAT", "arm=m", "dither=0"]
   -
     name: arc_brn
     detectorMap:

--- a/python/pfs/pipe2d/weekly/test_weekly.py
+++ b/python/pfs/pipe2d/weekly/test_weekly.py
@@ -100,7 +100,7 @@ class ProductionTestCase(lsst.utils.tests.TestCase):
 
 @classParameters(
     arms=("brn", "m"),
-    visit=(39, 40),
+    visit=(42, 43),
 )
 class ArcTestCase(lsst.utils.tests.TestCase):
     def setUp(self):

--- a/weekly/create_weekly.sh
+++ b/weekly/create_weekly.sh
@@ -153,7 +153,7 @@ make_brn 10 --pfsDesignId $PFS_DESIGN_ID --exptime 0 --type bias
 # Darks
 make_brn 10 --pfsDesignId $PFS_DESIGN_ID --exptime 1800 --type dark
 # Dithered flats
-make_brn 3 --pfsDesignId $PFS_DESIGN_ID --exptime 30 --type flat --xoffset 0
+make_brmn 3 --pfsDesignId $PFS_DESIGN_ID --exptime 30 --type flat --xoffset 0
 make_brn 3 --pfsDesignId $PFS_DESIGN_ID --exptime 30 --type flat --xoffset 2000
 make_brn 3 --pfsDesignId $PFS_DESIGN_ID --exptime 30 --type flat --xoffset 4000
 make_brn 3 --pfsDesignId $PFS_DESIGN_ID --exptime 30 --type flat --xoffset -2000

--- a/weekly/process_weekly.sh
+++ b/weekly/process_weekly.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DATADIR="/projects/HSC/PFS/weekly/weekly-20230808"
+DATADIR="/projects/HSC/PFS/weekly/weekly-20230925"
 RERUN="weekly"
 CORES=10
 CLEANUP=true


### PR DESCRIPTION
reduceProfiles.py is an alternative fiber profile construction code that fits profiles to multiple images simultaneously, and is preferred for use on Subaru data because some cobras cannot be hidden.

The syntax of generateCommand.py's input YAML files also changes with this commit because the command line syntax of `reduceProfiles.py` is different from that of constructFiberProfiles.